### PR TITLE
Allowing for placeholders with apostrophes

### DIFF
--- a/src/constants/editor/create_quill.ts
+++ b/src/constants/editor/create_quill.ts
@@ -45,7 +45,7 @@ export const create_quill = ({
   ${customJS}
   var quill = new Quill('#${id}', {
     modules: { ${modules} },
-    placeholder: '${placeholder}',
+    placeholder: "${placeholder}",
     theme: '${theme}'
   });
   </script>


### PR DESCRIPTION
I found that whenever I had a placeholder with an apostrophe, (i.e. "What's happening today?"), that the editor would fail to render. This simple PR fixes that.